### PR TITLE
forcefully set content type as "application/json; charset=utf-8"

### DIFF
--- a/src/Query/CurlQuery.php
+++ b/src/Query/CurlQuery.php
@@ -78,7 +78,7 @@ class CurlQuery
     /**
      * @return Authentication
      */
-    public function auth(): AuthenticationresponseType
+    public function auth(): Authentication
     {
         if (!$this->auth) {
             $this->auth = new Authentication();


### PR DESCRIPTION
There is a case when there is no content-type header is set. 
To make it work there is a need to forcefully set content type as "application/json; charset=utf-8"